### PR TITLE
Downgrade pydantic for Home Assistant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Changelog = "https://github.com/hacf-fr/sfrbox-api/releases"
 python = ">=3.9,<4.0"
 httpx = ">=0.23.1"
 defusedxml = ">=0.7.1"
-pydantic = ">=1.10.13"
+pydantic = ">=1.10.12"
 click = { version = ">=8.0.1", optional = true }
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
In HA it is pinned to 1.10.12