### PR TITLE
Add call history support

### DIFF
--- a/src/sfrbox_api/bridge.py
+++ b/src/sfrbox_api/bridge.py
@@ -243,8 +243,7 @@ class SFRBox:
         calls: list[VoipCallHistoryEntry] = []
         for call in xml_response.findall("calls/call"):
             call_details = self._create_class(VoipCallHistoryEntry, call)
-            if call_details is not None:
-                calls.append(call_details)
+            calls.append(call_details)  # type: ignore[arg-type]
         return VoipCallHistory(entries=calls)
 
     async def wan_get_info(self) -> WanInfo | None:

--- a/src/sfrbox_api/bridge.py
+++ b/src/sfrbox_api/bridge.py
@@ -26,6 +26,8 @@ from .exceptions import SFRBoxError
 from .models import DslInfo
 from .models import FtthInfo
 from .models import SystemInfo
+from .models import VoipCallHistory
+from .models import VoipCallHistoryEntry
 from .models import WanInfo
 from .models import WlanClient
 from .models import WlanClientList
@@ -231,6 +233,19 @@ class SFRBox:
         """Redémarrer la BOX."""
         token = await self._ensure_token()
         await self._send_post("system", "reboot", token=token)
+
+    async def voip_get_call_history(self) -> VoipCallHistory:
+        """Renvoie l'historique des appels VoIP."""
+        token = await self._ensure_token()
+        xml_response = await self._send_get_simple(
+            "voip", "getCallhistoryList", token=token
+        )
+        calls: list[VoipCallHistoryEntry] = []
+        for call in xml_response.findall("calls/call"):
+            call_details = self._create_class(VoipCallHistoryEntry, call)
+            if call_details is not None:
+                calls.append(call_details)
+        return VoipCallHistory(entries=calls)
 
     async def wan_get_info(self) -> WanInfo | None:
         """Renvoie les informations génériques sur la connexion internet."""

--- a/src/sfrbox_api/bridge.py
+++ b/src/sfrbox_api/bridge.py
@@ -26,9 +26,8 @@ from .exceptions import SFRBoxError
 from .models import DslInfo
 from .models import FtthInfo
 from .models import SystemInfo
-
-from .models import VoipCallHistory
-from .models import VoipCallHistoryEntry
+from .models import VoipCallHistoryCall
+from .models import VoipCallHistoryList
 from .models import VoipInfo
 from .models import WanInfo
 from .models import WlanClient
@@ -236,17 +235,17 @@ class SFRBox:
         token = await self._ensure_token()
         await self._send_post("system", "reboot", token=token)
 
-    async def voip_get_call_history(self) -> VoipCallHistory:
+    async def voip_get_call_history_list(self) -> VoipCallHistoryList:
         """Renvoie l'historique des appels VoIP."""
         token = await self._ensure_token()
         xml_response = await self._send_get_simple(
             "voip", "getCallhistoryList", token=token
         )
-        calls: list[VoipCallHistoryEntry] = []
+        calls: list[VoipCallHistoryCall] = []
         for call in xml_response.findall("calls/call"):
-            call_details = self._create_class(VoipCallHistoryEntry, call)
+            call_details = self._create_class(VoipCallHistoryCall, call)
             calls.append(call_details)  # type: ignore[arg-type]
-        return VoipCallHistory(entries=calls)
+        return VoipCallHistoryList(entries=calls)
 
     async def voip_get_info(self) -> VoipInfo | None:
         """Renvoie les informations sur la voix sur IP."""

--- a/src/sfrbox_api/models.py
+++ b/src/sfrbox_api/models.py
@@ -132,6 +132,34 @@ class SystemInfo(DataClassDictMixin):
 
 
 @dataclass
+class VoipCallHistoryEntry(DataClassDictMixin):
+    """Entrée de l'historique des appels VoIP."""
+
+    type: str
+    """Type d'appel.
+
+    = (voip)"""
+    direction: str
+    """Direction de l'appel.
+
+    = (incoming|outgoing)"""
+    number: str
+    """Numéro de téléphone. Vide si le numéro est masqué."""
+    length: int
+    """Durée de l'appel en seconde. -1 si l'appel a été manqué."""
+    date: int
+    """Date de l'appel exprimé en secondes."""
+
+
+@dataclass
+class VoipCallHistory(DataClassDictMixin):
+    """Historique des appels VoIP."""
+
+    entries: "list[VoipCallHistoryEntry]"
+    """Liste des entrées de l'historique des appels VoIP."""
+
+
+@dataclass
 class WanInfo(DataClassDictMixin):
     """Informations génériques sur la connexion internet."""
 

--- a/src/sfrbox_api/models.py
+++ b/src/sfrbox_api/models.py
@@ -132,7 +132,7 @@ class SystemInfo(DataClassDictMixin):
 
 
 @dataclass
-class VoipCallHistoryEntry(DataClassDictMixin):
+class VoipCallHistoryCall(DataClassDictMixin):
     """Entrée de l'historique des appels VoIP."""
 
     type: str
@@ -152,10 +152,10 @@ class VoipCallHistoryEntry(DataClassDictMixin):
 
 
 @dataclass
-class VoipCallHistory(DataClassDictMixin):
+class VoipCallHistoryList(DataClassDictMixin):
     """Historique des appels VoIP."""
 
-    entries: "list[VoipCallHistoryEntry]"
+    entries: "list[VoipCallHistoryCall]"
     """Liste des entrées de l'historique des appels VoIP."""
 
 

--- a/tests/fixtures/voip.getCallHistory.xml
+++ b/tests/fixtures/voip.getCallHistory.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsp stat="ok" version="1.0">
+     <calls>
+
+      <call type="voip" direction="incoming" number="012345 XXXX" length="41" date="1774253416" />
+
+      <call type="voip" direction="incoming" number="067890 XXXX" length="18" date="1774253539" />
+
+      <call type="voip" direction="outgoing" number="18" length="665" date="1774254035" />
+
+      <call type="voip" direction="outgoing" number="18" length="3" date="1774258571" />
+
+      <call type="voip" direction="incoming" number="023456 XXXX" length="-1" date="1774309693" />
+
+      <call type="voip" direction="incoming" number="" length="17" date="1774339427" />
+
+   </calls>
+
+
+</rsp>

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -15,6 +15,8 @@ from sfrbox_api.exceptions import SFRBoxError
 from sfrbox_api.models import DslInfo
 from sfrbox_api.models import FtthInfo
 from sfrbox_api.models import SystemInfo
+from sfrbox_api.models import VoipCallHistory
+from sfrbox_api.models import VoipCallHistoryEntry
 from sfrbox_api.models import WanInfo
 from sfrbox_api.models import WlanClient
 from sfrbox_api.models import WlanClientList
@@ -404,6 +406,66 @@ async def test_system_reboot_bad_auth(mocked_responses: aioresponses) -> None:
             match=re.escape("Api call failed: [115] Authentication needed"),
         ):
             await box.system_reboot()
+
+
+@pytest.mark.asyncio
+async def test_voip_get_call_history(mocked_responses: aioresponses) -> None:
+    """It exits with a status code of zero."""
+    mocked_responses.get(
+        "http://192.168.0.1/api/1.0/?method=voip.getCallhistoryList&token=afd1baa4cb261bfc08ec2dc0ade3b4",
+        body=_load_fixture("voip.getCallHistory.xml"),
+    )
+    async with aiohttp.ClientSession() as client:
+        box = SFRBox(ip="192.168.0.1", client=client)
+        box._token = "afd1baa4cb261bfc08ec2dc0ade3b4"  # noqa: S105
+        box._token_time = time.time()
+        calls = await box.voip_get_call_history()
+        assert calls == VoipCallHistory(
+            entries=[
+                VoipCallHistoryEntry(
+                    type="voip",
+                    direction="incoming",
+                    number="012345 XXXX",
+                    length=41,
+                    date=1774253416,
+                ),
+                VoipCallHistoryEntry(
+                    type="voip",
+                    direction="incoming",
+                    number="067890 XXXX",
+                    length=18,
+                    date=1774253539,
+                ),
+                VoipCallHistoryEntry(
+                    type="voip",
+                    direction="outgoing",
+                    number="18",
+                    length=665,
+                    date=1774254035,
+                ),
+                VoipCallHistoryEntry(
+                    type="voip",
+                    direction="outgoing",
+                    number="18",
+                    length=3,
+                    date=1774258571,
+                ),
+                VoipCallHistoryEntry(
+                    type="voip",
+                    direction="incoming",
+                    number="023456 XXXX",
+                    length=-1,
+                    date=1774309693,
+                ),
+                VoipCallHistoryEntry(
+                    type="voip",
+                    direction="incoming",
+                    number="",
+                    length=17,
+                    date=1774339427,
+                ),
+            ]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -15,8 +15,8 @@ from sfrbox_api.exceptions import SFRBoxError
 from sfrbox_api.models import DslInfo
 from sfrbox_api.models import FtthInfo
 from sfrbox_api.models import SystemInfo
-from sfrbox_api.models import VoipCallHistory
-from sfrbox_api.models import VoipCallHistoryEntry
+from sfrbox_api.models import VoipCallHistoryCall
+from sfrbox_api.models import VoipCallHistoryList
 from sfrbox_api.models import VoipInfo
 from sfrbox_api.models import WanInfo
 from sfrbox_api.models import WlanClient
@@ -410,7 +410,7 @@ async def test_system_reboot_bad_auth(mocked_responses: aioresponses) -> None:
 
 
 @pytest.mark.asyncio
-async def test_voip_get_call_history(mocked_responses: aioresponses) -> None:
+async def test_voip_getcallhistorylist(mocked_responses: aioresponses) -> None:
     """It exits with a status code of zero."""
     mocked_responses.get(
         "http://192.168.0.1/api/1.0/?method=voip.getCallhistoryList&token=afd1baa4cb261bfc08ec2dc0ade3b4",
@@ -420,45 +420,45 @@ async def test_voip_get_call_history(mocked_responses: aioresponses) -> None:
         box = SFRBox(ip="192.168.0.1", client=client)
         box._token = "afd1baa4cb261bfc08ec2dc0ade3b4"  # noqa: S105
         box._token_time = time.time()
-        calls = await box.voip_get_call_history()
-        assert calls == VoipCallHistory(
+        calls = await box.voip_get_call_history_list()
+        assert calls == VoipCallHistoryList(
             entries=[
-                VoipCallHistoryEntry(
+                VoipCallHistoryCall(
                     type="voip",
                     direction="incoming",
                     number="012345 XXXX",
                     length=41,
                     date=1774253416,
                 ),
-                VoipCallHistoryEntry(
+                VoipCallHistoryCall(
                     type="voip",
                     direction="incoming",
                     number="067890 XXXX",
                     length=18,
                     date=1774253539,
                 ),
-                VoipCallHistoryEntry(
+                VoipCallHistoryCall(
                     type="voip",
                     direction="outgoing",
                     number="18",
                     length=665,
                     date=1774254035,
                 ),
-                VoipCallHistoryEntry(
+                VoipCallHistoryCall(
                     type="voip",
                     direction="outgoing",
                     number="18",
                     length=3,
                     date=1774258571,
                 ),
-                VoipCallHistoryEntry(
+                VoipCallHistoryCall(
                     type="voip",
                     direction="incoming",
                     number="023456 XXXX",
                     length=-1,
                     date=1774309693,
                 ),
-                VoipCallHistoryEntry(
+                VoipCallHistoryCall(
                     type="voip",
                     direction="incoming",
                     number="",


### PR DESCRIPTION
This allows to get the call history from the box. The test fixture includes multiple cases:
- Incoming calls
- Outgoing calls
- Missed call
- Hidden caller ID
- Normal geographical numbers
- Short number (emergency, in this case)

The fixture is extracted directly from the box. Those are real data, it's not crafted by hand. The only modification is the phone number anonymization.

Tested on
```
Version  	: NB6VAC-MAIN-R4.0.47h3
Profil d'accès  	: FTTH
Connectivité  	: IPv6 & IPv4 CGNAT 
```